### PR TITLE
Throw an exception when a metadata name has non-supported characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Master
+* Throw an exception when a metadata name has non-supported characters
 
 # 0.1.1
 * Add functional tests

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -123,6 +123,10 @@ class File implements HydratableInterface, IdentifiableInterface, LoadMetadataIn
 
     public function setAllMetadata(array $metadata): void
     {
+        foreach (array_keys($metadata) as $name) {
+            $this->checkMetadataName($name);
+        }
+
         $this->onPropertyChanged('metadata', $this->metadata, $metadata);
         $this->metadata = $metadata;
     }
@@ -135,6 +139,8 @@ class File implements HydratableInterface, IdentifiableInterface, LoadMetadataIn
      */
     public function setMetadata(string $name, string $value): void
     {
+        $this->checkMetadataName($name);
+
         $new = $this->metadata;
         $new[$name] = $value;
 
@@ -149,6 +155,8 @@ class File implements HydratableInterface, IdentifiableInterface, LoadMetadataIn
      */
     public function removeMetadata(string $name): void
     {
+        $this->checkMetadataName($name);
+
         $new = $this->metadata;
         unset($new[$name]);
 
@@ -165,11 +173,25 @@ class File implements HydratableInterface, IdentifiableInterface, LoadMetadataIn
      */
     public function getMetadata(string $name): ?string
     {
+       $this->checkMetadataName($name);
+
         if (isset($this->metadata[$name])) {
             return $this->metadata[$name];
         }
 
         return null;
+    }
+
+    /**
+     * Check that all metadata name characters are authorized characters
+     *
+     * @param string $name of the metadata
+     */
+    private function checkMetadataName(string $name): void
+    {
+        if (preg_match('#[^a-z0-9.-]#', $name)) {
+            throw new \InvalidArgumentException("Valid characters for metadata name are lowercase letters, digits, dot and hyphen");
+        }
     }
 
     public function hydrate(array $data, ObjectManagerInterface $objectManager): void

--- a/tests/Functional/FileTest.php
+++ b/tests/Functional/FileTest.php
@@ -21,7 +21,7 @@ class FileTest extends AbstractFunctionalTestCase
             ['myfilename.txt', null, ['filename' => 'myfilename.txt']],
             [null, null, []],
             [null, ['mymetadata' => 'myvalue'], ['mymetadata' => 'myvalue']],
-            ['myfilename.txt', ['mymetadata' => 'myvalue'], ['filename' => 'myfilename.txt', 'mymetadata' => 'myvalue']],
+            ['myfilename.txt', ['my.metadata-1' => 'myvalue'], ['filename' => 'myfilename.txt', 'my.metadata-1' => 'myvalue']],
         ];
     }
 

--- a/tests/Unit/Entity/FileTest.php
+++ b/tests/Unit/Entity/FileTest.php
@@ -74,13 +74,13 @@ class FileTest extends TestCase
             'metadata',
             [
                 [],
-                ['mymetadata1' => 'myvalue1'],
+                ['my-metadata1' => 'myvalue1'],
                 ['mymetadata2' => 'myvalue2', 'mymetadata3' => 'myvalue3']
             ]
         );
 
-        $sut->setAllMetadata(['mymetadata1' => 'myvalue1']);
-        $this->assertEquals(['mymetadata1' => 'myvalue1'], $sut->getAllMetadata());
+        $sut->setAllMetadata(['my-metadata1' => 'myvalue1']);
+        $this->assertEquals(['my-metadata1' => 'myvalue1'], $sut->getAllMetadata());
 
         $sut->setAllMetadata(['mymetadata2' => 'myvalue2', 'mymetadata3' => 'myvalue3']);
         $this->assertEquals(['mymetadata2' => 'myvalue2', 'mymetadata3' => 'myvalue3'], $sut->getAllMetadata());
@@ -95,16 +95,16 @@ class FileTest extends TestCase
             'metadata',
             [
                 [],
-                ['mymetadata1' => 'myvalue1'],
-                ['mymetadata1' => 'myvalue1', 'mymetadata2' => 'myvalue2']
+                ['my.metadata1' => 'myvalue1'],
+                ['my.metadata1' => 'myvalue1', 'mymetadata2' => 'myvalue2']
             ]
         );
 
-        $sut->setMetadata('mymetadata1', 'myvalue1');
-        $this->assertEquals(['mymetadata1' => 'myvalue1'], $sut->getAllMetadata());
+        $sut->setMetadata('my.metadata1', 'myvalue1');
+        $this->assertEquals(['my.metadata1' => 'myvalue1'], $sut->getAllMetadata());
 
         $sut->setMetadata('mymetadata2', 'myvalue2');
-        $this->assertEquals(['mymetadata1' => 'myvalue1', 'mymetadata2' => 'myvalue2'], $sut->getAllMetadata());
+        $this->assertEquals(['my.metadata1' => 'myvalue1', 'mymetadata2' => 'myvalue2'], $sut->getAllMetadata());
     }
 
     /**
@@ -403,5 +403,53 @@ class FileTest extends TestCase
 
         // Since @doesNotPerformAssertions doesn't allow to perform code coverage
         $this->assertTrue(true);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Valid characters for metadata name are lowercase letters, digits, dot and hyphen
+     *
+     * @covers ::checkMetadataName
+     */
+    public function testSetMetadataWithInvalidNameShouldThrowException(): void
+    {
+        $sut = new File();
+        $sut->setMetadata('myName', 'myvalue');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Valid characters for metadata name are lowercase letters, digits, dot and hyphen
+     *
+     * @covers ::checkMetadataName
+     */
+    public function testGetMetadataWithInvalidNameShouldThrowException(): void
+    {
+        $sut = new File();
+        $sut->getMetadata('my_name');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Valid characters for metadata name are lowercase letters, digits, dot and hyphen
+     *
+     * @covers ::checkMetadataName
+     */
+    public function testRemoveMetadataWithInvalidNameShouldThrowException(): void
+    {
+        $sut = new File();
+        $sut->removeMetadata('my,name');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Valid characters for metadata name are lowercase letters, digits, dot and hyphen
+     *
+     * @covers ::checkMetadataName
+     */
+    public function testsetAllMetadataWithInvalidNameShouldThrowException(): void
+    {
+        $sut = new File();
+        $sut->setAllMetadata(['myname' => 'myvalue', 'my:name' => 'myvalue']);
     }
 }


### PR DESCRIPTION
Closes #5 